### PR TITLE
Add scoreboard API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,7 @@
 
 	<groupId>vg.civcraft.mc.civmodcore</groupId>
 	<artifactId>CivModCore</artifactId>
-	<version>1.7.0</version>
-
+	<version>1.7.3</version>
 	<name>CivModCore</name>
 	<url>https://github.com/DevotedMC/CivModCore/</url>
 

--- a/src/main/java/vg/civcraft/mc/civmodcore/ACivMod.java
+++ b/src/main/java/vg/civcraft/mc/civmodcore/ACivMod.java
@@ -15,6 +15,7 @@ import vg.civcraft.mc.civmodcore.dao.ManagedDatasource;
 import vg.civcraft.mc.civmodcore.interfaces.ApiManager;
 import vg.civcraft.mc.civmodcore.inventorygui.ClickableInventoryListener;
 import vg.civcraft.mc.civmodcore.itemHandling.NiceNames;
+import vg.civcraft.mc.civmodcore.scoreboard.ScoreBoardListener;
 
 public abstract class ACivMod extends JavaPlugin {
 
@@ -49,6 +50,7 @@ public abstract class ACivMod extends JavaPlugin {
 	private void registerEvents() {
 		getServer().getPluginManager().registerEvents(new ClickableInventoryListener(), this);
 		getServer().getPluginManager().registerEvents(new ChatListener(), this);
+		getServer().getPluginManager().registerEvents(new ScoreBoardListener(), this);
 	}
 
 	@Deprecated

--- a/src/main/java/vg/civcraft/mc/civmodcore/scoreboard/CivScoreBoard.java
+++ b/src/main/java/vg/civcraft/mc/civmodcore/scoreboard/CivScoreBoard.java
@@ -1,0 +1,87 @@
+package vg.civcraft.mc.civmodcore.scoreboard;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TreeMap;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.DisplaySlot;
+import org.bukkit.scoreboard.Objective;
+import org.bukkit.scoreboard.Score;
+import org.bukkit.scoreboard.Scoreboard;
+
+public class CivScoreBoard {
+
+	private String scoreName;
+	private Map<UUID, String> currentScoreText;
+	private static final String title = "  Info  ";
+
+	CivScoreBoard(String scoreName) {
+		this.scoreName = scoreName;
+		this.currentScoreText = new TreeMap<>();
+	}
+	
+	public String getName() {
+		return scoreName;
+	}
+
+	public void set(Player p, String text) {
+		String oldText = get(p);
+		if (oldText != null) {
+			System.out.println("Resetting " + oldText);
+			p.getScoreboard().resetScores(oldText);
+		}
+		else {
+			ScoreBoardAPI.adjustScore(p.getUniqueId(), 1);
+		}
+		Score score = getObjective(p).getScore(text);
+		score.setScore(0);
+		System.out.println("Setting score for " + text);
+		currentScoreText.put(p.getUniqueId(), text);
+	}
+
+	public String get(Player p) {
+		return currentScoreText.get(p.getUniqueId());
+	}
+
+	public void hide(Player p) {
+		String text = get(p);
+		if (text == null) {
+			return;
+		}
+		p.getScoreboard().resetScores(text);
+		currentScoreText.remove(p.getUniqueId());
+		ScoreBoardAPI.adjustScore(p.getUniqueId(), -1);
+	}
+	
+	void tearDown() {
+		for(Entry<UUID,String> entry : currentScoreText.entrySet()) {
+			Player p = Bukkit.getPlayer(entry.getKey());
+			if (p == null) {
+				continue;
+			}
+			p.getScoreboard().resetScores(entry.getValue());
+		}
+		currentScoreText.clear();
+	}
+	
+	void purge(Player p) {
+		currentScoreText.remove(p.getUniqueId());
+	}
+
+	private Objective getObjective(Player p) {
+		Scoreboard scb = p.getScoreboard();
+		Objective objective = scb.getObjective(title);
+		if (objective == null) {
+			System.out.println("Making new obj");
+			scb.getObjectives().forEach(o -> o.unregister());
+			scb.clearSlot(DisplaySlot.SIDEBAR);
+			objective = scb.registerNewObjective(title, "dummy");
+			objective.setDisplaySlot(DisplaySlot.SIDEBAR);
+		}
+		return objective;
+	}
+
+}

--- a/src/main/java/vg/civcraft/mc/civmodcore/scoreboard/ScoreBoardAPI.java
+++ b/src/main/java/vg/civcraft/mc/civmodcore/scoreboard/ScoreBoardAPI.java
@@ -1,0 +1,61 @@
+package vg.civcraft.mc.civmodcore.scoreboard;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.DisplaySlot;
+
+public class ScoreBoardAPI {
+	
+	private static Map<UUID, Integer> openScores = new TreeMap<>();
+	private static Map<String, CivScoreBoard> boards = new HashMap<>();
+	
+	public static CivScoreBoard createBoard(String key) {
+		CivScoreBoard board = new CivScoreBoard(key);
+		boards.put(key, board);
+		return board;
+	}
+	
+	public static CivScoreBoard getBoard(String key) {
+		return boards.get(key);
+	}
+	
+	public static void deleteBoard(CivScoreBoard board) {
+		boards.remove(board.getName());
+		board.tearDown();
+	}
+	
+	static void purge(Player p) {
+		for(CivScoreBoard board : boards.values()) {
+			board.purge(p);
+		}
+		openScores.remove(p.getUniqueId());
+	}
+	
+	static void adjustScore(UUID uuid, int amount) {
+		Integer current = openScores.get(uuid);
+		if (current == null) {
+			current = 0;
+		}
+		current += amount;
+		if (current <= 0) {
+			Player p = Bukkit.getPlayer(uuid);
+			if (p != null) {
+				resetPlayer(p);
+			}
+			openScores.remove(uuid);
+		}
+		else {
+			openScores.put(uuid, current);
+		}
+	}
+	
+	static void resetPlayer(Player p) {
+		p.setScoreboard(Bukkit.getScoreboardManager().getNewScoreboard());
+	}
+
+}

--- a/src/main/java/vg/civcraft/mc/civmodcore/scoreboard/ScoreBoardListener.java
+++ b/src/main/java/vg/civcraft/mc/civmodcore/scoreboard/ScoreBoardListener.java
@@ -1,0 +1,18 @@
+package vg.civcraft.mc.civmodcore.scoreboard;
+
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.scoreboard.DisplaySlot;
+import org.bukkit.scoreboard.ScoreboardManager;
+
+public class ScoreBoardListener implements Listener {
+	
+	@EventHandler
+	public void join(PlayerJoinEvent e) {
+		e.getPlayer().setScoreboard(Bukkit.getScoreboardManager().getNewScoreboard());
+	}
+
+}


### PR DESCRIPTION
This adds an API for creating and modifying score boards easily.

Here's a mock of what we could be doing with this: https://cdn.discordapp.com/attachments/542076086998007848/554027210852401172/2019-03-09_20.45.33.png


Here is a working example integrated with Finale to show pearl cooldown (also recorded my spotify music for some reason):

https://streamable.com/w2ur7
