### PR TITLE
Update pom.xml with missing dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
 							<artifactSet>
 								<includes>
 									<include>com.zaxxer:HikariCP</include>
+									<include>org.slf4j:slf4j-api</include>
 									<include>org.apache.logging.*</include>
 								</includes>
 							</artifactSet>
@@ -123,6 +124,11 @@
 			<groupId>com.zaxxer</groupId>
 			<artifactId>HikariCP</artifactId>
 			<version>3.3.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.26</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Not having this dependency causes this line to fail: 

https://github.com/DevotedMC/CivModCore/blob/4a1b4efb6b9541d57057c6e2d06980f69c705a88/src/main/java/vg/civcraft/mc/civmodcore/dao/ConnectionPool.java#L52

with such errors:

```
[18:41:51] [Server thread/ERROR]: Could not call method 'public static vg.civcraft.mc.civmodcore.dao.ManagedDatasource vg.civcraft.mc.civmodcore.dao.ManagedDatasource.deserialize(java.util.Map)' of class vg.civcraft.mc.civmodcore.dao.ManagedDatasource for deserialization
java.lang.NoClassDefFoundError: org/slf4j/LoggerFactory
        at com.zaxxer.hikari.HikariConfig.<clinit>(HikariConfig.java:51) ~[?:?]
```

```
[18:41:51] [Server thread/ERROR]: Could not call method 'public static vg.civcraft.mc.civmodcore.dao.ManagedDatasource vg.civcraft.mc.civmodcore.dao.ManagedDatasource.valueOf(java.util.Map)' of class vg.civcraft.mc.civmodcore.dao.ManagedDatasource for deserialization
java.lang.NoClassDefFoundError: Could not initialize class com.zaxxer.hikari.HikariConfig
        at vg.civcraft.mc.civmodcore.dao.ConnectionPool.<init>(ConnectionPool.java:52) ~[?:?]
```