### PR TITLE
Fix tracker not adding items

### DIFF
--- a/src/main/java/vg/civcraft/mc/civmodcore/util/progress/ProgressTracker.java
+++ b/src/main/java/vg/civcraft/mc/civmodcore/util/progress/ProgressTracker.java
@@ -59,4 +59,8 @@ public class ProgressTracker<T extends ProgressTrackable> {
 		addItem(trackable);
 	}
 
+	public boolean containsItem(T trackable) {
+		return queueItems.contains(trackable);
+	}
+
 }

--- a/src/main/java/vg/civcraft/mc/civmodcore/util/progress/ProgressTracker.java
+++ b/src/main/java/vg/civcraft/mc/civmodcore/util/progress/ProgressTracker.java
@@ -20,7 +20,7 @@ public class ProgressTracker<T extends ProgressTrackable> {
 	}
 
 	public void addItem(T trackable) {
-		if (trackable.getNextUpdate() == Long.MAX_VALUE) {
+		if (trackable.getNextUpdate() != Long.MAX_VALUE) {
 			queueItems.add(trackable);
 		}
 	}


### PR DESCRIPTION
This condition prevents items to be added in most cases because items are not likely to have `Long.MAX_VALUE` as a `nextUpdate` value.
https://github.com/DevotedMC/CivModCore/blob/37285d9f9c83cf4b2903372f10531acc8265c769/src/main/java/vg/civcraft/mc/civmodcore/util/progress/ProgressTracker.java#L22-L26