### PR TITLE
Maybe fix getCenteredInOrder & Pony Trie fix

### DIFF
--- a/src/main/java/vg/civcraft/mc/civmodcore/command/Trie.java
+++ b/src/main/java/vg/civcraft/mc/civmodcore/command/Trie.java
@@ -64,7 +64,7 @@ public final class Trie {
 			return matches;
 		}
 		int elementsToRemove = args.length - 1;
-		for (int i = 0; i < args.length; i++) {
+		for (int i = 0; i < matches.size(); i++) {
 			String mod = matches.get(i);
 			int startingSpot = StringUtils.ordinalIndexOf(mod, " ", elementsToRemove) + 1;
 			matches.set(i, mod.substring(startingSpot));

--- a/src/main/java/vg/civcraft/mc/civmodcore/inventorygui/components/ContentAligners.java
+++ b/src/main/java/vg/civcraft/mc/civmodcore/inventorygui/components/ContentAligners.java
@@ -48,7 +48,7 @@ public class ContentAligners {
 		if (contentAmount % rowLength == 0) {
 			offset = 1;
 		}
-		int lastElementLastCompleteRow = ((contentAmount / rowLength) + offset) * rowLength - 1;
+		int lastElementLastCompleteRow = (((contentAmount / rowLength) + offset) * rowLength - 1) + rowLength;
 
 		return new Counter(i -> {
 			// just increment until we reach the last element in the last full row
@@ -56,10 +56,10 @@ public class ContentAligners {
 				return i + 1;
 			} else {
 				// jump to offset start of last row
-				int lengthLastRow = contentAmount - lastElementLastCompleteRow - 1;
+				int lengthLastRow = (contentAmount + rowLength) - lastElementLastCompleteRow - 1;
 				int emptySlots = rowLength - lengthLastRow;
 				int leftOffset = Math.max(1, emptySlots / 2);
-				return i + leftOffset;
+				return (i + 1) + leftOffset;
 			}
 		}, defaultNum);
 	}


### PR DESCRIPTION
From my perspective, the counter wasn't accounting for the row offset from the top, we simply just add on the row length to account for that and aswell as in the counter we add 1 since that doesn't occur if i is equal to lastElementLastCompleteRow